### PR TITLE
set anonymizeIp to true in Google Analytics set up

### DIFF
--- a/src/main/webapp/resources/celJS/initCelements.js
+++ b/src/main/webapp/resources/celJS/initCelements.js
@@ -678,6 +678,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', gaaNum, window.getCelDomain());
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
       console.log('finish initalizing google universal analytics.', gaaNum);
     }
@@ -817,7 +818,7 @@
   celAddOnBeforeLoadListener(function() {
     cel_initDateTimePicker();
   });
-  
+
   /**
    * Initialize close Window on Overlay CloseButton
    */
@@ -827,7 +828,7 @@
       elem.observe("click", cel_closeOverlayWindow)
     });
   });
-  
+
   var cel_closeOverlayWindow = function(event) {
     event.stop();
     window.close();


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-681

Before Approving / Merging we should discuss, if we want to allow deactivating the anonymisation via a configuration.
Right now I don't see a reason why we should allow it. I'm not aware of any customers with a legitimate interest in tracking specific visitors in contrast to just use aggregated data for statistical purposes.