### PR TITLE
CELDEV-828 xmlbeans included twice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,7 @@
                 <exclude>WEB-INF/lib/tika-parsers-0.8.jar</exclude>
                 <exclude>WEB-INF/lib/rome-0.9.jar</exclude>
                 <exclude>WEB-INF/lib/xml-apis-1.3.03.jar</exclude>
+                <exclude>WEB-INF/lib/xmlbeans-*.jar</exclude>
                 <exclude>WEB-INF/lib/css4j-0.10.jar</exclude>
                 <exclude>WEB-INF/lib/commons-compress-1.1.jar</exclude>
                 <exclude>WEB-INF/lib/reflections-*.jar</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>com.celements</groupId>
       <artifactId>celements-search</artifactId>
-      <version>4.0-M1</version>
+      <version>4.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>xalan</groupId>


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-828

- exlude xmlbeans (2.0.3) from xwiki-enterprise 2.7.2