### PR TITLE
CELDEV-998 - update celements-image dependency to 5.4-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>com.celements</groupId>
       <artifactId>image-web</artifactId>
-      <version>5.3</version>
+      <version>5.4-SNAPSHOT</version>
       <type>war</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-998