### PR TITLE
Load cel-lazy-load content on DOM connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
     <dependency>
       <groupId>com.celements</groupId>
       <artifactId>celements-search</artifactId>
-      <version>6.4</version>
+      <version>6.5-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.celements</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
     <dependency>
       <groupId>com.celements</groupId>
       <artifactId>celements-core</artifactId>
-      <version>6.16</version>
+      <version>6.17-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.celements</groupId>

--- a/src/main/webapp/resources/celDynJS/DynamicLoader/celLazyLoader.mjs
+++ b/src/main/webapp/resources/celDynJS/DynamicLoader/celLazyLoader.mjs
@@ -275,12 +275,8 @@ class CelLazyLoader extends HTMLElement {
   }
 
   #updateContent(newChildNodes) {
-    console.debug('updateContent: ', newChildNodes);
     const parent = this.parentNode;
-    if (!parent) {
-      console.debug('cel-lazy-load: no parent when updating, aborting');
-      return;
-    }
+    if (!parent) return; // element is detached
     try {
       const fragment = new DocumentFragment();
       fragment.replaceChildren(...newChildNodes);
@@ -315,19 +311,14 @@ class CelLazyLoader extends HTMLElement {
       if (response.ok) {
         return await response.text();
       } else {
-        console.error('fetchHtml failed', response);
+        console.error('fetch failed', response);
       }
     } catch (exp) {
-      if (exp.name === 'AbortError') {
-        console.debug('fetch aborted for cel-lazy-load', this);
-      } else {
-        console.error('fetch error', exp);
-      }
+      if (exp.name !== 'AbortError') console.error('fetch error', exp);
     }
   }
 
   async connectedCallback() {
-    console.debug('connectedCallback', this);
     this.#attachLoadingIndicator();
     this.classList.add('celLoadLazyLoading');
     const html = await this.fetchHtml();

--- a/src/main/webapp/resources/celDynJS/DynamicLoader/celLazyLoader.mjs
+++ b/src/main/webapp/resources/celDynJS/DynamicLoader/celLazyLoader.mjs
@@ -253,6 +253,11 @@ if (!customElements.get('cel-lazy-load-css')) {
  * CelLazyLoader loads the html-response of src attribute
  *********************************************************/
 class CelLazyLoader extends HTMLElement {
+  static CSS_CLASSES = Object.freeze({
+    LOADING: 'cel-lazy-loading',
+    REMOVING: 'cel-lazy-removing',
+  });
+
   #abortController;
 
   constructor () {
@@ -268,15 +273,24 @@ class CelLazyLoader extends HTMLElement {
     return parseInt(this.getAttribute('loader-size')) || parseInt(this.getAttribute('size'));
   }
 
+  async connectedCallback() {
+    this.#attachLoadingIndicator();
+    const html = await this.fetchHtml();
+    const nodes = this.#parseHTML(html ?? '');
+    await this.#updateContent(nodes);
+  }
+
   #parseHTML(html) {
     const template = document.createElement('template');
     template.insertAdjacentHTML('afterbegin', html);
     return [...template.childNodes];
   }
 
-  #updateContent(newChildNodes) {
-    const parent = this.parentNode;
-    if (!parent) return; // element is detached
+  async #updateContent(newChildNodes) {
+    if (!this.parentNode) return; // element still attached ?
+    await this.#animateRemoval();
+      const parent = this.parentNode;
+    if (!parent) return; // element still attached ?
     try {
       const fragment = new DocumentFragment();
       fragment.replaceChildren(...newChildNodes);
@@ -286,6 +300,17 @@ class CelLazyLoader extends HTMLElement {
       console.error('updateContent failed on', parent, exp);
     }
   }
+
+  async #animateRemoval() {
+    if (!this.getAnimations) return;
+    this.classList.add(CelLazyLoader.CSS_CLASSES.REMOVING);
+    try {
+      const animations = this.getAnimations().map((animation) => animation.finished);
+      return await Promise.all(animations);
+    } finally {
+      this.classList.remove(CelLazyLoader.CSS_CLASSES.REMOVING);
+    }
+  } 
 
   #attachLoadingIndicator() {
     if (!window.CELEMENTS?.LoadingIndicator || !this.loaderSize) return;
@@ -307,6 +332,7 @@ class CelLazyLoader extends HTMLElement {
   async fetchHtml() {
     if (!this.src) return;
     try {
+      this.classList.add(CelLazyLoader.CSS_CLASSES.LOADING);
       const response = await fetch(this.src, { signal: this.#abortController.signal });
       if (response.ok) {
         return await response.text();
@@ -315,15 +341,9 @@ class CelLazyLoader extends HTMLElement {
       }
     } catch (exp) {
       if (exp.name !== 'AbortError') console.error('fetch error', exp);
+    } finally {
+      this.classList.remove(CelLazyLoader.CSS_CLASSES.LOADING);
     }
-  }
-
-  async connectedCallback() {
-    this.#attachLoadingIndicator();
-    this.classList.add('celLoadLazyLoading');
-    const html = await this.fetchHtml();
-    const nodes = this.#parseHTML(html ?? '');
-    this.#updateContent(nodes);
   }
 
   disconnectedCallback() {

--- a/src/main/webapp/resources/celDynJS/DynamicLoader/celLazyLoader.mjs
+++ b/src/main/webapp/resources/celDynJS/DynamicLoader/celLazyLoader.mjs
@@ -253,63 +253,90 @@ if (!customElements.get('cel-lazy-load-css')) {
  * CelLazyLoader loads the html-response of src attribute
  *********************************************************/
 class CelLazyLoader extends HTMLElement {
-    
+  #abortController;
+
   constructor () {
     super();
-    this._lazyLoadUtils = new CelLazyLoaderUtils();
-    this.classList.add('celLoadLazyLoading');
-    this._fetchResponse = this.src ? fetch(this.src) : null;
-    this.attachShadow({ 'mode' : 'open' });
-    this._loadingIndicator = new window.CELEMENTS.LoadingIndicator();
-    this._showLoadingIndicator();
+    this.#abortController = new AbortController();
   }
 
   get src() {
     return this.getAttribute('src');
   }
 
-  _parseHTML(html) {
+  get loaderSize() {
+    return parseInt(this.getAttribute('loader-size')) || parseInt(this.getAttribute('size'));
+  }
+
+  #parseHTML(html) {
     const template = document.createElement('template');
     template.insertAdjacentHTML('afterbegin', html);
     return [...template.childNodes];
   }
 
-  _updateContent(newChildNodes) {
-    console.debug('_updateContent: ', newChildNodes);
+  #updateContent(newChildNodes) {
+    console.debug('updateContent: ', newChildNodes);
     const parent = this.parentNode;
-    const fragment = new DocumentFragment();
-    fragment.replaceChildren(...newChildNodes);
-    parent.replaceChild(fragment, this);
+    if (!parent) {
+      console.debug('cel-lazy-load: no parent when updating, aborting');
+      return;
+    }
     try {
-      this._lazyLoadUtils.fireEvent(parent, 'celements:contentChanged', {
-        'htmlElem': parent
-      });
+      const fragment = new DocumentFragment();
+      fragment.replaceChildren(...newChildNodes);
+      parent.replaceChild(fragment, this);
+      new CelLazyLoaderUtils().fireEvent(parent, 'celements:contentChanged', { 'htmlElem': parent });
     } catch (exp) {
-      console.error('contentChanged failed on ', parent, exp);
+      console.error('updateContent failed on', parent, exp);
     }
   }
 
-  _showLoadingIndicator() {
-    const loaderSize = parseInt(this.getAttribute('size')) || 64;
-    const loaderimg = this._loadingIndicator.getLoadingIndicator(loaderSize);
-    loaderimg.style.display = 'block';
-    loaderimg.style.marginLeft = 'auto';
-    loaderimg.style.marginRight = 'auto';
-    this.shadowRoot.appendChild(loaderimg);
+  #attachLoadingIndicator() {
+    if (!window.CELEMENTS?.LoadingIndicator || !this.loaderSize) return;
+    try {
+      const celLoadingIndicator = new window.CELEMENTS.LoadingIndicator();
+      const loaderImg = celLoadingIndicator.getLoadingIndicator(this.loaderSize);
+      loaderImg.style.display = 'block';
+      loaderImg.style.marginLeft = 'auto';
+      loaderImg.style.marginRight = 'auto';
+      if (!this.shadowRoot) {
+        this.attachShadow({ 'mode' : 'open' });
+      }
+      this.shadowRoot.appendChild(loaderImg);
+    } catch (exp) {
+      console.error('attachLoadingIndicator failed', exp);
+    }
+  }
+
+  async fetchHtml() {
+    if (!this.src) return;
+    try {
+      const response = await fetch(this.src, { signal: this.#abortController.signal });
+      if (response.ok) {
+        return await response.text();
+      } else {
+        console.error('fetchHtml failed', response);
+      }
+    } catch (exp) {
+      if (exp.name === 'AbortError') {
+        console.debug('fetch aborted for cel-lazy-load', this);
+      } else {
+        console.error('fetch error', exp);
+      }
+    }
   }
 
   async connectedCallback() {
-    console.debug('connectedCallback', this, this._fetchResponse);
-    let nodes = [];
-    if (this._fetchResponse) {
-      const response = await this._fetchResponse;
-      if (response.ok) {
-        nodes = this._parseHTML(await response.text());
-      } else {
-        console.error('fetch failed', response);
-      }
-    }
-    this._updateContent(nodes);
+    console.debug('connectedCallback', this);
+    this.#attachLoadingIndicator();
+    this.classList.add('celLoadLazyLoading');
+    const html = await this.fetchHtml();
+    const nodes = this.#parseHTML(html ?? '');
+    this.#updateContent(nodes);
+  }
+
+  disconnectedCallback() {
+    this.#abortController.abort();
   }
 }
 


### PR DESCRIPTION
`document.createElement('cel-lazy-load')` caused a `DOMException: Operation is not supported` due to side effects in the constructor. moved relevant logic to connectedCallback