### PR TITLE
Initialize translations as empty object

### DIFF
--- a/src/main/webapp/resources/uicomponents/viewers/comments.js
+++ b/src/main/webapp/resources/uicomponents/viewers/comments.js
@@ -6,7 +6,7 @@ var XWiki = (function (XWiki) {
    * Javascript enhancements for the comments viewer.
    */
   viewers.Comments = Class.create({
-    translations: translations,
+    translations: {},
     xcommentSelector: '.xwikicomment',
     /** Constructor. Adds all the JS improvements of the Comments area. */
     initialize: function () {


### PR DESCRIPTION
fix `comments.js?version=20260324011336:9 Uncaught ReferenceError: translations is not defined`