### PR TITLE
Bugfix/hidden attribute in slide show

### DIFF
--- a/src/main/webapp/resources/celDynJS/overlay/celOverlay.mjs
+++ b/src/main/webapp/resources/celDynJS/overlay/celOverlay.mjs
@@ -18,8 +18,8 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { CelOverlayResize } from "./overlayResize.mjs?version=202212031733";
-import "../DynamicLoader/celLazyLoader.mjs?version=202301052318";
+import { CelOverlayResize } from './overlayResize.mjs?version=202212031733';
+import '../DynamicLoader/celLazyLoader.mjs?version=202301052318';
 
 export class CelOverlay {
   /** class field definition and private fields only works for > Safari 14.5, Dec 2021,
@@ -39,13 +39,15 @@ export class CelOverlay {
     Object.assign(this, window.CELEMENTS.mixins.Observable);
     this._isOpen = false;
     this._loadingIndicator = new window.CELEMENTS.LoadingIndicator();
-    this.idPrefix = idPrefix || "celOverlay_";
+    this.idPrefix = idPrefix || 'celOverlay_';
     this._id = this._generateNextId(this.idPrefix);
     this._closeBind = this.close.bind(this);
     this._escapeHandlerBind = this._escapeHandler.bind(this);
-    const cssFiles = [{
-        'src' : '/file/resources/celRes/overlay/celementsOverlayV2.css'
-      }];
+    const cssFiles = [
+      {
+        src: '/file/resources/celRes/overlay/celementsOverlayV2.css',
+      },
+    ];
     if (customCssFiles) {
       cssFiles.push(...customCssFiles);
     }
@@ -80,7 +82,7 @@ export class CelOverlay {
 
   _getOverlayResizer() {
     if (!this._overlayResizer) {
-      this._overlayResizer= new CelOverlayResize(this);
+      this._overlayResizer = new CelOverlayResize(this);
     }
     return this._overlayResizer;
   }
@@ -142,8 +144,8 @@ export class CelOverlay {
       document.body.appendChild(overlayElem);
       this._overlayElem = overlayElem;
       this.celFire('celOverlay:afterRender', {
-        'overlayElem' : overlayElem,
-        'overlay' : this
+        overlayElem: overlayElem,
+        overlay: this,
       });
     }
     return this._overlayElem;
@@ -166,7 +168,7 @@ export class CelOverlay {
   }
 
   _escapeHandler(ev) {
-    if(ev.key === "Escape"){
+    if (ev.key === 'Escape') {
       ev.preventDefault();
       ev.stopPropagation();
       this.close();
@@ -196,18 +198,18 @@ export class CelOverlay {
       console.warn('skip "open" because overlay is already opened. Call "close" first');
     }
   }
-  
+
   async openCelementsPage(url) {
     this.open();
     if (url) {
       await this._loadContentAsync({
-       'url' : url,
-        'responseField' : 'celrenderedcontent',
-        'title' : data => (data.title || data.name)
+        url: url,
+        responseField: 'celrenderedcontent',
+        title: (data) => data.title || data.name,
       });
     }
   }
-  
+
   _parseHTML(html) {
     const elem = document.createElement('div');
     elem.insertAdjacentHTML('afterbegin', html);
@@ -221,10 +223,10 @@ export class CelOverlay {
       const response = await fetch(loadObj.url, {
         method: 'POST',
         redirect: 'follow',
-        body: params
+        body: params,
       });
       if (response.ok) {
-        const data = await response.json() ?? {};
+        const data = (await response.json()) ?? {};
         this.updateContent(this._parseHTML(data[loadObj.responseField]));
         this.title = loadObj.title(data);
       } else {
@@ -232,8 +234,8 @@ export class CelOverlay {
       }
     } catch (error) {
       const event = this.celFire('celOverlay:asyncLoadFailed', {
-        'overlay' : this,
-        'error' : err
+        overlay: this,
+        error: error,
       });
       if (!event.stopped) {
         this.updateContent(this._parseHTML('<p class="celErrMessage">Loading failed.</p>'));
@@ -241,13 +243,13 @@ export class CelOverlay {
       }
     }
   }
-  
+
   _getLoadingImg() {
     const loaderimg = this._loadingIndicator.getLoadingIndicator(64);
     Object.assign(loaderimg.style, {
-      display : 'block',
-      marginLeft : 'auto',
-      marginRight : 'auto'
+      display: 'block',
+      marginLeft: 'auto',
+      marginRight: 'auto',
     });
     return loaderimg;
   }
@@ -278,7 +280,6 @@ export class CelOverlay {
       console.warn('skip "close" because overlay is already closed. Call "open" first');
     }
   }
-
 }
 
 // For non module javascripts

--- a/src/main/webapp/resources/celJS/celpresentation/CelementsSlideShow.js
+++ b/src/main/webapp/resources/celJS/celpresentation/CelementsSlideShow.js
@@ -116,7 +116,7 @@
         const elemHideInfo = {
           elem: elem,
           wasHiddenAttr: elem.readAttribute('hidden') !== null,
-          wasDisplayNone: elem.getStyle('display') === 'none',
+          wasDisplayNone: elem.style.display === 'none',
         };
         elem.removeAttribute('hidden');
         elem.show();
@@ -131,12 +131,10 @@
        */
       _hideElem: function (elemHideInfo) {
         const elem = elemHideInfo.elem;
-        const wasHiddenAttr = elemHideInfo.wasHiddenAttr;
-        const wasDisplayNone = elemHideInfo.wasDisplayNone;
-        if (wasHiddenAttr) {
+        if (elemHideInfo.wasHiddenAttr) {
           elem.writeAttribute('hidden', true);
         }
-        if (wasDisplayNone) {
+        if (elemHideInfo.wasDisplayNone) {
           elem.hide();
         }
       },

--- a/src/main/webapp/resources/celJS/celpresentation/CelementsSlideShow.js
+++ b/src/main/webapp/resources/celJS/celpresentation/CelementsSlideShow.js
@@ -106,6 +106,30 @@
         _me._gotoSlideClickHandlerBind = _me._gotoSlideClickHandler.bind(_me);
       },
 
+      /**
+       * Shows an element regardless of whether it was hidden via display:none
+       * or the HTML `hidden` attribute.
+       * Prototype 1.7.3 visible() returns false for both, but show() only
+       * removes display:none, so we must also remove the hidden attribute.
+       */
+      _showElem: function (elem) {
+        elem.removeAttribute('hidden');
+        elem.show();
+      },
+
+      /**
+       * Hides an element and restores it to exactly the same hidden state it
+       * was in before a paired _showElem call.
+       * Pass the `wasHiddenAttr` flag that was captured before _showElem was
+       * called to decide whether the hidden attribute must be put back.
+       */
+      _hideElem: function (elem, wasHiddenAttr) {
+        elem.hide();
+        if (wasHiddenAttr) {
+          elem.writeAttribute('hidden', true);
+        }
+      },
+
       setCounterLeadingZeros: function (useLeadingZeros) {
         const _me = this;
         _me._counterLeadingZeros = useLeadingZeros;
@@ -664,12 +688,15 @@
         const _me = this;
         const slideWrapper = slideWrapperIn || _me._getSlideWrapper();
         const slideRoot = _me._getSlideRootElem(slideWrapper);
-        //we cannot read element dimension if any parent is hidden (display:none)
+        //we cannot read element dimension if any parent is hidden
         const hiddenParentElems = [];
         slideWrapper.ancestors().each(function (parentElem) {
           if (!parentElem.visible()) {
-            hiddenParentElems.push(parentElem);
-            parentElem.show();
+            hiddenParentElems.push({
+              elem: parentElem,
+              wasHiddenAttr: parentElem.readAttribute('hidden') !== null,
+            });
+            _me._showElem(parentElem);
           }
         });
         //ensure that the width is not influenced by the parents by setting position to absolute
@@ -707,7 +734,9 @@
         //--> see method comment
         const topPos = (parentHeight - slideOuterHeight) / 2;
         const leftPos = (parentWidth - slideOuterWidth) / 2;
-        hiddenParentElems.each(Element.hide);
+        hiddenParentElems.each(function (entry) {
+          _me._hideElem(entry.elem, entry.wasHiddenAttr);
+        });
         slideWrapper.setStyle({
           position: 'relative',
           margin: '0',
@@ -897,8 +926,11 @@
         const hiddenParentElems = [];
         slideWrapper.ancestors().each(function (parentElem) {
           if (!parentElem.visible()) {
-            hiddenParentElems.push(parentElem);
-            parentElem.show();
+            hiddenParentElems.push({
+              elem: parentElem,
+              wasHiddenAttr: parentElem.readAttribute('hidden') !== null,
+            });
+            _me._showElem(parentElem);
           }
         });
         const oldWidth = parseInt(slideWrapper.getWidth());
@@ -923,7 +955,9 @@
           position: rootPositionValue,
           visibility: '',
         });
-        hiddenParentElems.each(Element.hide);
+        hiddenParentElems.each(function (entry) {
+          _me._hideElem(entry.elem, entry.wasHiddenAttr);
+        });
         return {
           zoomFactor: zoomFactor,
           oldHeight: oldHeight,

--- a/src/main/webapp/resources/celJS/celpresentation/CelementsSlideShow.js
+++ b/src/main/webapp/resources/celJS/celpresentation/CelementsSlideShow.js
@@ -113,8 +113,14 @@
        * removes display:none, so we must also remove the hidden attribute.
        */
       _showElem: function (elem) {
+        const elemHideInfo = {
+          elem: elem,
+          wasHiddenAttr: elem.readAttribute('hidden') !== null,
+          wasDisplayNone: elem.getStyle('display') === 'none',
+        };
         elem.removeAttribute('hidden');
         elem.show();
+        return elemHideInfo;
       },
 
       /**
@@ -123,10 +129,15 @@
        * Pass the `wasHiddenAttr` flag that was captured before _showElem was
        * called to decide whether the hidden attribute must be put back.
        */
-      _hideElem: function (elem, wasHiddenAttr) {
-        elem.hide();
+      _hideElem: function (elemHideInfo) {
+        const elem = elemHideInfo.elem;
+        const wasHiddenAttr = elemHideInfo.wasHiddenAttr;
+        const wasDisplayNone = elemHideInfo.wasDisplayNone;
         if (wasHiddenAttr) {
           elem.writeAttribute('hidden', true);
+        }
+        if (wasDisplayNone) {
+          elem.hide();
         }
       },
 
@@ -692,11 +703,7 @@
         const hiddenParentElems = [];
         slideWrapper.ancestors().each(function (parentElem) {
           if (!parentElem.visible()) {
-            hiddenParentElems.push({
-              elem: parentElem,
-              wasHiddenAttr: parentElem.readAttribute('hidden') !== null,
-            });
-            _me._showElem(parentElem);
+            hiddenParentElems.push(_me._showElem(parentElem));
           }
         });
         //ensure that the width is not influenced by the parents by setting position to absolute
@@ -734,9 +741,7 @@
         //--> see method comment
         const topPos = (parentHeight - slideOuterHeight) / 2;
         const leftPos = (parentWidth - slideOuterWidth) / 2;
-        hiddenParentElems.each(function (entry) {
-          _me._hideElem(entry.elem, entry.wasHiddenAttr);
-        });
+        hiddenParentElems.each(_me._hideElem);
         slideWrapper.setStyle({
           position: 'relative',
           margin: '0',
@@ -926,11 +931,7 @@
         const hiddenParentElems = [];
         slideWrapper.ancestors().each(function (parentElem) {
           if (!parentElem.visible()) {
-            hiddenParentElems.push({
-              elem: parentElem,
-              wasHiddenAttr: parentElem.readAttribute('hidden') !== null,
-            });
-            _me._showElem(parentElem);
+            hiddenParentElems.push(_me._showElem(parentElem));
           }
         });
         const oldWidth = parseInt(slideWrapper.getWidth());
@@ -955,9 +956,7 @@
           position: rootPositionValue,
           visibility: '',
         });
-        hiddenParentElems.each(function (entry) {
-          _me._hideElem(entry.elem, entry.wasHiddenAttr);
-        });
+        hiddenParentElems.each(_me._hideElem);
         return {
           zoomFactor: zoomFactor,
           oldHeight: oldHeight,


### PR DESCRIPTION
- correct CelementsSlideShow to handle hidden attribute correctly after upgrade to prototype.js 1.7.3
- _loadContentAsync of CelOverlay has a bug in the on disk version -> catch (error) but references err instead of error (lines 236, 240). Would throw a ReferenceError.

