### PR TITLE
add support for setup-script on recursive appScripts

### DIFF
--- a/celements-webapp/src/main/webapp/templates/app.vm
+++ b/celements-webapp/src/main/webapp/templates/app.vm
@@ -5,15 +5,9 @@
   #parse($services.appscript.getAppScriptTemplatePath("$!celAppScriptSetup"))
 #else
   #set($celAppScript = $services.appscript.getScriptNameFromURL())
-  #set($appRecursiveScript = $services.appscript.getAppRecursiveScript("$!celAppScript"))
-  #if($appRecursiveScript)
-    #set($indexOfPlus = $appRecursiveScript.lastIndexOf("++"))
-    #if($indexOfPlus > 0)
-      #set($recSetupName = "${appRecursiveScript.substring(0, $indexOfPlus)}_setup++")
-      #if($services.appscript.isAppScriptAvailable($recSetupName))
-        #parse($services.appscript.getAppScriptTemplatePath($recSetupName))
-      #end
-    #end
+  #set($recSetupName = $services.appscript.getAppRecursiveSetupScript("$!celAppScript"))
+  #if($recSetupName)
+    #parse($services.appscript.getAppScriptTemplatePath($recSetupName))
   #end
 #end
 $xwiki.parseTemplate("frameheader.vm")

--- a/celements-webapp/src/main/webapp/templates/app.vm
+++ b/celements-webapp/src/main/webapp/templates/app.vm
@@ -2,7 +2,19 @@
 #set($overwriteRenderDocument = 'celInlineTemplates/app.vm')
 #set($celAppScriptSetup = "$!{services.appscript.getScriptNameFromURL()}_setup")
 #if($services.appscript.isAppScriptAvailable("$!celAppScriptSetup"))
-#parse($services.appscript.getAppScriptTemplatePath("$!celAppScriptSetup"))
+  #parse($services.appscript.getAppScriptTemplatePath("$!celAppScriptSetup"))
+#else
+  #set($celAppScript = $services.appscript.getScriptNameFromURL())
+  #set($appRecursiveScript = $services.appscript.getAppRecursiveScript("$!celAppScript"))
+  #if($appRecursiveScript)
+    #set($indexOfPlus = $appRecursiveScript.lastIndexOf("++"))
+    #if($indexOfPlus > 0)
+      #set($recSetupName = "${appRecursiveScript.substring(0, $indexOfPlus)}_setup++")
+      #if($services.appscript.isAppScriptAvailable($recSetupName))
+        #parse($services.appscript.getAppScriptTemplatePath($recSetupName))
+      #end
+    #end
+  #end
 #end
 $xwiki.parseTemplate("frameheader.vm")
 #if(!$contextIsFinished)


### PR DESCRIPTION
## Summary

Adds setup-script support for recursive appScripts in `app.vm`.

Previously, `app.vm` only parsed the direct appScript setup template named `<script>_setup`. This change keeps that behavior unchanged, and when no direct setup script exists, it now resolves the matching recursive appScript and looks for a corresponding `<recursive-script>_setup++` template.

## Details

- Preserves existing direct setup-script handling.
- Falls back to `services.appscript.getAppRecursiveScript(...)` when no direct setup script is available.
- Derives the recursive setup script name by replacing the trailing `++` with `_setup++`.
- Parses the recursive setup template only if it is available.

**only merge after https://github.com/celements/celements-core/pull/413**
