### PR TITLE
correct celements-admin-frontend version to 0.1.0-snapshot

### DIFF
--- a/celements-admin-frontend/package-lock.json
+++ b/celements-admin-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@celements/admin-frontend",
-  "version": "0.1.0",
+  "version": "0.1.0-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@celements/admin-frontend",
-      "version": "0.1.0",
+      "version": "0.1.0-SNAPSHOT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.2.0",
         "@fortawesome/free-solid-svg-icons": "^7.2.0",

--- a/celements-admin-frontend/package.json
+++ b/celements-admin-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celements/admin-frontend",
-  "version": "0.1.0",
+  "version": "0.1.0-SNAPSHOT",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Description
Following the successful build and deployment of the `0.1.0` release of `celements-admin-frontend`, this PR updates the version to `0.1.0-SNAPSHOT` to return the project to its active development/working state.
