### PR TITLE
Fix refactoring mistakes

### DIFF
--- a/celements-webapp/src/main/webapp/resources/js/xwiki/importer/import.js
+++ b/celements-webapp/src/main/webapp/resources/js/xwiki/importer/import.js
@@ -1,14 +1,7 @@
 var XWiki = (function (XWiki) {
   var importer = (XWiki.importer = XWiki.importer || {});
 
-  let translations = {};
-  if (window.celExecOnceAfterMessagesLoaded) {
-    window.celExecOnceAfterMessagesLoaded(
-      (celMessages) => (translations = celMessages.celAdminImport),
-    );
-  } else {
-    console.warn('celExecOnceAfterMessagesLoaded not available!');
-  }
+  let translations;
 
   /**
    * Initialization hook for the rich UI.
@@ -34,7 +27,10 @@ var XWiki = (function (XWiki) {
 
           // Create a package explorer widget to let the user browse
           // and select/unselect the documents he wants.
-          new importer.PackageExplorer('packagecontainer', decodeURIComponent(file));
+          window.celExecOnceAfterMessagesLoaded((celMessages) => {
+            translations = celMessages.celAdminImport;
+            new importer.PackageExplorer('packagecontainer', decodeURIComponent(file));
+          });
         },
       );
     });

--- a/celements-webapp/src/main/webapp/templates/plainpagetype.vm
+++ b/celements-webapp/src/main/webapp/templates/plainpagetype.vm
@@ -1,5 +1,5 @@
 ##only include if legacy celements2web.xar is installed
-#if($services.modelAccess($services.model.resolveDocument('celements2web:Macros.initCelements')))
+#if($services.modelAccess.exists($services.model.resolveDocument('celements2web:Macros.initCelements')))
 $xwiki.includeForm("celements2web:Macros.initCelements", false)
 #end
 ## start a Celements Document

--- a/celements-webapp/src/main/webapp/templates/rename.vm
+++ b/celements-webapp/src/main/webapp/templates/rename.vm
@@ -32,7 +32,7 @@
         $response.setStatus(400)
         #error($msg.get('core.rename.emptyName'))
         #template("renameStep1.vm")
-      #elseif($services.modelAccess.exists($newFullName))
+      #elseif($services.modelAccess.exists($services.model.resolveDocument($newFullName)))
         $response.setStatus(409)
         #error("$msg.get('core.rename.alreadyExists', [$newFullName, $xwiki.getURL($newFullName)])")
         #template("renameStep1.vm")
@@ -56,7 +56,7 @@
         #set ($oldDocName = $doc.fullName)
 
 ##        $doc.rename($newFullName, $renamedBLs, $children)
-$services.celementsweb.renameDoc($oldDocName, $newFullName)
+$services.celementsweb.renameDoc($doc.documentReference, $newFullName)
 
         #xwikimessageboxstart("$msg.get('notice')" "$msg.get('core.rename.success', [$oldDocName, $doc.fullName, $xwiki.getURL($doc.fullName)])")
         #xwikimessageboxend()

--- a/celements-webapp/src/main/webapp/templates/xwikivars.vm
+++ b/celements-webapp/src/main/webapp/templates/xwikivars.vm
@@ -12,7 +12,7 @@
 ## Note: The document name is not internally used to determine if a user has programming access level. We pass XWiki.XWikiPreferences for consistency with the call for global admin
 #set ($hasProgramming = $xwiki.hasAccessLevel('programming', $xcontext.user, 'XWiki.XWikiPreferences'))
 #set ($hasSpaceAdmin = $xwiki.hasAccessLevel('admin', $xcontext.user, "${doc.space}.WebPreferences"))
-#set ($hasWatch = $xwiki.watchlist && !$isGuest && !$isSuperAdmin && $services.modelAccess.exists($services.model.createDocumentReference($xcontext.wiki, 'XWiki', 'XWikiUserWatchListSheet'), 'local'))
+#set ($hasWatch = $xwiki.watchlist && !$isGuest && !$isSuperAdmin && $services.modelAccess.exists($services.model.createDocumentReference($xcontext.wiki, 'XWiki', 'XWikiUserWatchListSheet')))
 ##
 ## Are comments, attachments, history etc. enabled?
 ##


### PR DESCRIPTION
Fix refactoring regressions [introduced](https://github.com/celements/celements-web/pull/511) while migrating from deprecated plugin APIs to modern script services:

  - Pass document references to modelAccess.exists and celementsweb.renameDoc.
  - Call modelAccess.exists correctly in plainpagetype.vm.
  - Remove the unsupported local argument from the watchlist document check.
  - Wait for translated messages before creating the package importer, preventing missing labels caused by a race condition.