### PR TITLE
Fix production loading of VueFinder vendor styles

### DIFF
--- a/celements-admin-frontend/vite.config.ts
+++ b/celements-admin-frontend/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig(({ mode }) => getViteConfig(mode));
 export const getViteConfig = (mode: string) => {
   const env = loadEnv(mode, process.cwd());
   return defineConfig({
+    base: mode === 'production' ? '/static/' : '/',
     plugins: [
       vue({
         template: {

--- a/celements-webapp/src/main/webapp/templates/celAppScripts/cel/admin/MediaLib.vm
+++ b/celements-webapp/src/main/webapp/templates/celAppScripts/cel/admin/MediaLib.vm
@@ -9,8 +9,8 @@ $!jsService.includeExtJsFile($extJsParamSync.setJsFile(':celJS/tailwind/tailwind
 <script type="module" src="http://localhost:5173/@vite/client"></script>
 <script type="module" src="http://localhost:5173/src/embedded.ts"></script>
 #else
-<link rel="stylesheet" href="/static/assets/embedded.css" />
-<script type="module" src="/static/assets/embedded.js"></script>
+<link rel="stylesheet" href="/static/assets/embedded.css?ver=${services.celementsweb.getLastStartupTimeStamp()}" />
+<script type="module" src="/static/assets/embedded.js?ver=${services.celementsweb.getLastStartupTimeStamp()}"></script>
 #end
 
 <div class="cel_cell" id="userAdmin">

--- a/celements-webapp/src/main/webapp/templates/celAppScripts/cel/admin/MediaLib.vm
+++ b/celements-webapp/src/main/webapp/templates/celAppScripts/cel/admin/MediaLib.vm
@@ -9,9 +9,9 @@ $!jsService.includeExtJsFile($extJsParamSync.setJsFile(':celJS/tailwind/tailwind
 <script type="module" src="http://localhost:5173/@vite/client"></script>
 <script type="module" src="http://localhost:5173/src/embedded.ts"></script>
 #else
-<link rel="stylesheet" href="/static/assets/embedded.css?ver=${services.celementsweb.getLastStartupTimeStamp()}" />
-<link rel="stylesheet" href="/static/assets/vendor.css?ver=${services.celementsweb.getLastStartupTimeStamp()}" />
-<script type="module" src="/static/assets/embedded.js?ver=${services.celementsweb.getLastStartupTimeStamp()}"></script>
+<link rel="stylesheet" href="/static/assets/embedded.css?ver=$!{services.celementsweb.getLastStartupTimeStamp()}" />
+<link rel="stylesheet" href="/static/assets/vendor.css?ver=$!{services.celementsweb.getLastStartupTimeStamp()}" />
+<script type="module" src="/static/assets/embedded.js?ver=$!{services.celementsweb.getLastStartupTimeStamp()}"></script>
 #end
 
 <div class="cel_cell" id="userAdmin">

--- a/celements-webapp/src/main/webapp/templates/celAppScripts/cel/admin/MediaLib.vm
+++ b/celements-webapp/src/main/webapp/templates/celAppScripts/cel/admin/MediaLib.vm
@@ -10,6 +10,7 @@ $!jsService.includeExtJsFile($extJsParamSync.setJsFile(':celJS/tailwind/tailwind
 <script type="module" src="http://localhost:5173/src/embedded.ts"></script>
 #else
 <link rel="stylesheet" href="/static/assets/embedded.css?ver=${services.celementsweb.getLastStartupTimeStamp()}" />
+<link rel="stylesheet" href="/static/assets/vendor.css?ver=${services.celementsweb.getLastStartupTimeStamp()}" />
 <script type="module" src="/static/assets/embedded.js?ver=${services.celementsweb.getLastStartupTimeStamp()}"></script>
 #end
 

--- a/celements-webapp/src/main/webapp/templates/celAppScripts/cel/admin/PageAttachments++.vm
+++ b/celements-webapp/src/main/webapp/templates/celAppScripts/cel/admin/PageAttachments++.vm
@@ -9,9 +9,9 @@ $!jsService.includeExtJsFile($extJsParamSync.setJsFile(':celJS/tailwind/tailwind
 <script type="module" src="http://localhost:5173/@vite/client"></script>
 <script type="module" src="http://localhost:5173/src/embedded.ts"></script>
 #else
-<link rel="stylesheet" href="/static/assets/embedded.css?ver=${services.celementsweb.getLastStartupTimeStamp()}" />
-<link rel="stylesheet" href="/static/assets/vendor.css?ver=${services.celementsweb.getLastStartupTimeStamp()}" />
-<script type="module" src="/static/assets/embedded.js?ver=${services.celementsweb.getLastStartupTimeStamp()}"></script>
+<link rel="stylesheet" href="/static/assets/embedded.css?ver=$!{services.celementsweb.getLastStartupTimeStamp()}" />
+<link rel="stylesheet" href="/static/assets/vendor.css?ver=$!{services.celementsweb.getLastStartupTimeStamp()}" />
+<script type="module" src="/static/assets/embedded.js?ver=$!{services.celementsweb.getLastStartupTimeStamp()}"></script>
 #end
 
 <div class="cel_cell" id="userAdmin">

--- a/celements-webapp/src/main/webapp/templates/celAppScripts/cel/admin/PageAttachments++.vm
+++ b/celements-webapp/src/main/webapp/templates/celAppScripts/cel/admin/PageAttachments++.vm
@@ -9,8 +9,9 @@ $!jsService.includeExtJsFile($extJsParamSync.setJsFile(':celJS/tailwind/tailwind
 <script type="module" src="http://localhost:5173/@vite/client"></script>
 <script type="module" src="http://localhost:5173/src/embedded.ts"></script>
 #else
-<link rel="stylesheet" href="/static/assets/embedded.css" />
-<script type="module" src="/static/assets/embedded.js"></script>
+<link rel="stylesheet" href="/static/assets/embedded.css?ver=${services.celementsweb.getLastStartupTimeStamp()}" />
+<link rel="stylesheet" href="/static/assets/vendor.css?ver=${services.celementsweb.getLastStartupTimeStamp()}" />
+<script type="module" src="/static/assets/embedded.js?ver=${services.celementsweb.getLastStartupTimeStamp()}"></script>
 #end
 
 <div class="cel_cell" id="userAdmin">


### PR DESCRIPTION
## Summary

- Configure Vite to resolve production assets through `/static/`.
- Explicitly load `vendor.css` alongside `embedded.css` in the MediaLib and PageAttachments templates.
- Add asset version parameters to prevent stale frontend resources.
- Preserve the existing Vite development-server behavior on localhost.
- Fix missing VueFinder rules such as `.vuefinder__menubar__item` on celdev deployments.