### PR TITLE
CELDEV-1334 Deploy navigation REST component

### DIFF
--- a/celements-webapp/pom.xml
+++ b/celements-webapp/pom.xml
@@ -226,6 +226,10 @@
     </dependency>
     <dependency>
       <groupId>com.celements</groupId>
+      <artifactId>celements-navigation-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.celements</groupId>
       <artifactId>celements-core</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-1334
## Summary

- add `com.celements:celements-navigation-rest` as a webapp runtime component dependency
- package the new controller for Spring discovery under the existing `/api` servlet mapping

## Coordinated delivery

Draft 4 of 4 for CELDEV-1334.

- ADR: celements/celements-spring#31
- REST module: celements/celements-base#309
- BOM management: celements/celements-parent-poms#142

Merge and publication order must preserve those dependencies before deploying the webapp.

## Validation

- clean Maven verify from `/home/fpichler/git/celements-web`: successful
- banned dependencies and dependency convergence: passed
- TypeScript and Vite build: passed
- WAR packaging: passed; embedded REST JAR matched the coordinated base artifact
- local container restarted against the rebuilt bind-mounted webapp
- guest navigation request returned 200 with `private, no-store`
- invalid reference and parameter smoke checks returned the documented safe 400 responses
- manually tested and approved by the requester