### PR TITLE
CELDEV-874 - Prevent FormNG completion-rule Velocity injection

### DIFF
--- a/celements-webapp/src/main/webapp/templates/celTemplates/FormNGView.vm
+++ b/celements-webapp/src/main/webapp/templates/celTemplates/FormNGView.vm
@@ -70,7 +70,7 @@ $xwiki.includeForm("celements2web:Macros.getActionTypeAndActionTemplateDoc", fal
   #set($oneComplete = false)
   #if("$!{formActionObj.getProperty('completeRuleSnippet').getValue()}" != "")
     #set($H = '#') #set($d = '$')
-    #set($execStr = "${H}set(${d}oneComplete = $!{formActionObj.completeRuleSnippet})")
+    #set($execStr = "${H}set(${d}oneComplete = $!{formActionObj.getProperty('completeRuleSnippet').getValue()})")
     #set($!res = $!xwiki.renderText($execStr, $doc))
   #else
     #set($oneComplete = $filled)


### PR DESCRIPTION
## Summary

- read `completeRuleSnippet` through its raw property value instead of rendered Velocity shorthand
- prevent request data from entering generated Velocity source before the explicit `renderText` evaluation

## Validation

- `mvn -f celements-webapp/pom.xml -DskipTests compile`
- `git diff --check`

Jira: https://synjira.atlassian.net/browse/CELDEV-874
Follow-up refactoring: https://synjira.atlassian.net/browse/CELDEV-1339